### PR TITLE
Use bundles to group dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,19 +2,11 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.3"
 
-Compile / scalacOptions ++= Seq(
-  "-deprecation",
-  "-feature",
-  "-unchecked",
-  "-Xlog-reflective-calls",
-  "-Xlint"
-)
+Compile / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -24,55 +16,23 @@ Test / logBuffered := false
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-val AkkaVersion = "2.6.12"
-val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
-val AkkaPersistenceJdbcVersion = "5.0.0"
-val AlpakkaKafkaVersion = "2.0.6"
-val AkkaProjectionVersion = "1.1.0"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
-
 enablePlugins(JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"
 dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
+libraryDependencies ++=
+  AkkaPlatform.httpServer ++
+  AkkaPlatform.clusterSharding ++
+  AkkaPlatform.clusterManagement ++
+  AkkaPlatform.persistenceJdbc ++
+  AkkaPlatform.projectionJdbc
+
 libraryDependencies ++= Seq(
-  // 1. Basic dependencies for a clustered application
-  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  // Akka Management powers Health Checks and Akka Cluster Bootstrapping
-  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
-  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
-  "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagementVersion,
-  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-  // Common dependencies for logging and testing
-  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test,
-  // 2. Using gRPC and/or protobuf
-  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-  // 3. Using Akka Persistence
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
-  "com.lightbend.akka" %% "akka-persistence-jdbc" % AkkaPersistenceJdbcVersion,
-  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
   "org.postgresql" % "postgresql" % "42.2.18",
-  // 4. Querying or projecting data from Akka Persistence
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
-  "com.lightbend.akka" %% "akka-projection-jdbc" % AkkaProjectionVersion,
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
-  "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
-  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion)

--- a/project/AkkaPlatform.scala
+++ b/project/AkkaPlatform.scala
@@ -1,0 +1,112 @@
+object AkkaPlatform {
+
+  val AkkaVersion = "2.6.12"
+  val AkkaHttpVersion = "10.2.3"
+  val AkkaManagementVersion = "1.0.9"
+  val AkkaPersistenceJdbcVersion = "5.0.0"
+  val AkkaPersistenceCassandraVersion = "1.0.4"
+  val AlpakkaKafkaVersion = "2.0.6"
+  val AkkaProjectionVersion = "1.1.0"
+
+  object artifacts {
+    // 1. Basic dependencies for a clustered application
+    val akkaStream = "com.typesafe.akka" %% "akka-stream" % AkkaVersion
+    val akkaCluster = "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion
+    val akkaClusterSharding = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion
+    val akkaTestKit = "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test
+    val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test
+
+    // Akka Management powers Health Checks and Akka Cluster Bootstrapping
+    val akkaMng = "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion
+    val akkaHttp = "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion
+    val akkaHttpJson = "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion
+    val akkaMngClusterHttp = "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion
+    val akkaMngClusterBootstrap =
+      "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion
+    val akkaDiscoveryKubeApi = "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagementVersion
+    val akkaDiscovery = "com.typesafe.akka" %% "akka-discovery" % AkkaVersion
+
+    // Common dependencies for logging and testing
+    val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion
+    val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
+    val scalaTest = "org.scalatest" %% "scalatest" % "3.1.2" % Test
+
+    // 2. Using gRPC and/or protobuf
+    val akkaHttp2 = "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion
+
+    // 3. Using Akka Persistence
+    val akkaPersistence = "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion
+    val akkaJackson = "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion
+    val akkaPersistenceJdbc = "com.lightbend.akka" %% "akka-persistence-jdbc" % AkkaPersistenceJdbcVersion
+    val akkaPersistenceCassandra = "com.lightbend.akka" %% "akka-persistence-cassandra" % AkkaPersistenceJdbcVersion
+    val akkaPersistenceTestKit = "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test
+
+    // 4. Querying or projecting data from Akka Persistence
+    val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion
+    val akkaProjectionEventSourced = "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion
+    val akkaProjectionJdbc = "com.lightbend.akka" %% "akka-projection-jdbc" % AkkaProjectionVersion
+    val akkaProjectionCassandra = "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion
+    val akkaProjectionSlick = "com.lightbend.akka" %% "akka-projection-slick" % AkkaProjectionVersion
+    val akkaProjectionKafka = "com.lightbend.akka" %% "akka-projection-kafka" % AkkaProjectionVersion
+    val akkaStreamKafka = "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion
+    val akkaProjectionTestkit = "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
+
+  }
+  import artifacts._
+
+  /**
+   * Dependencies to build a minimal Akka Cluster
+   */
+  val clusterSharding = Seq(akkaCluster, akkaClusterSharding, akkaJackson, logback, akkaSlf4j)
+
+  /**
+   * Akka Management
+   */
+  val clusterManagement = Seq(akkaMng, akkaMngClusterHttp, akkaMngClusterBootstrap, akkaDiscovery, akkaDiscoveryKubeApi)
+
+  /**
+   * Dependencies to build a minimal Akka Http Server
+   */
+  val httpServer = Seq(akkaHttp, akkaHttpJson, akkaHttp2, logback, akkaSlf4j)
+
+  //--------------------------------------------------------------------------------
+  // Akka Persistence
+  private val minimalPersistence = Seq(akkaPersistence, akkaJackson, akkaPersistenceTestKit)
+
+  /**
+   * base dependencies for a write-side using JDBC
+   */
+  val persistenceJdbc = minimalPersistence :+ akkaPersistenceJdbc
+
+  /**
+   * base dependencies for a write-side using Cassandra
+   */
+  val persistenceCassandra = minimalPersistence :+ akkaPersistenceCassandra
+  //--------------------------------------------------------------------------------
+
+  //--------------------------------------------------------------------------------
+  // Akka Projections
+  private val minimalProjection =
+    Seq(akkaPersistenceQuery, akkaProjectionEventSourced, akkaProjectionTestkit)
+
+  /**
+   * base dependencies for a read-side projection using JDBC
+   */
+  val projectionJdbc = minimalProjection :+ akkaProjectionJdbc
+
+  /**
+   * base dependencies for a read-side projection using Slick
+   */
+  val projectionSlick = minimalProjection :+ akkaProjectionSlick
+
+  /**
+   * base dependencies for a read-side projection using Cassandra
+   */
+  val projectionCassandra = minimalProjection :+ akkaProjectionCassandra
+
+  /**
+   * base dependencies for a read-side projection using Kafka
+   */
+  val projecitonKafka = minimalProjection :+ akkaProjectionKafka
+  //--------------------------------------------------------------------------------
+}


### PR DESCRIPTION
This illustrates how a sbt BOM could look like. 

Users start with such a template would get an empty shell. 

Users can choose which bundles to select using `AkkaPlatform`, for instance:

```scala
// cluster consuming from kafka and projection to jdbc
libraryDependencies ++=
  AkkaPlatform.httpServer ++
  AkkaPlatform.clusterSharding ++
  AkkaPlatform.projectionKafka ++
  AkkaPlatform.projectionJdbc
```


```scala
// cluster consuming from cassandra journal and projection to jdbc
libraryDependencies ++=
  AkkaPlatform.httpServer ++
  AkkaPlatform.clusterSharding ++
  AkkaPlatform.persistenceCassandra ++
  AkkaPlatform.projectionJdbc
```

Some artifacts may not be in a bundle, they would be accessible via `AkkaPlatform.artifacts`. 


