### PR TITLE
Reduce power: only pass a sub-Config

### DIFF
--- a/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    fromConfig(system.settings.config.getConfig("jdbc-connection-settings"))
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -28,7 +28,7 @@ object ScalikeJdbcSetup {
   }
 
   /**
-   * Builds a Hikari DataSource with values from jdbc-connection-settings.
+   * Builds a Hikari DataSource with values from 
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
   def fromConfig(config: Config): Unit = {
@@ -39,26 +39,16 @@ object ScalikeJdbcSetup {
     val dataSource = new HikariDataSource()
 
     dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
 
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+    val timeout =config.getDuration("connection-pool.timeout").toMillis
     dataSource.setConnectionTimeout(timeout)
+    dataSource.setMaximumPoolSize(config.getInt("connection-pool.max-pool-size"))
 
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
-
-    ConnectionPool.singleton(
-      new DataSourceConnectionPool(
-        dataSource = dataSource,
-        closer = HikariCloser(dataSource)))
+    ConnectionPool.singleton(new DataSourceConnectionPool(dataSource = dataSource, closer = HikariCloser(dataSource)))
   }
 
   /**
@@ -73,8 +63,7 @@ object ScalikeJdbcSetup {
   /**
    * ScalikeJdbc needs a closer for the DataSource to delegate the closing call.
    */
-  private case class HikariCloser(dataSource: HikariDataSource)
-      extends DataSourceCloser {
+  private case class HikariCloser(dataSource: HikariDataSource) extends DataSourceCloser {
     override def close(): Unit = dataSource.close()
   }
 


### PR DESCRIPTION
`ScalikeJdbcSetup.fromConfig` gets a full `Config` because it's a method doing two different things: creating the Hikari DataSource _and_ initializing the ScalikeJdbc backend. I'm not s super fan of passing a full `Config` around.